### PR TITLE
Provide alternate styling for open glossary terms.

### DIFF
--- a/js/adapt-contrib-glossaryItemView.js
+++ b/js/adapt-contrib-glossaryItemView.js
@@ -57,16 +57,20 @@ define(function(require) {
             }
         },
 
-        // This function should show the glossary item description.
+        // This function should show the glossary item description and highlight the selected term.
         showGlossaryItemDescription: function() {
             this.$('.glossary-item-description').slideDown(200);
             this.model.set('_isDescriptionOpen', true);
+
+            this.$('.glossary-item-term').addClass('selected');
         },
 
-        // This function should hide the glossary item description.
+        // This function should hide the glossary item description and un-highlight the selected term.
         hideGlossaryItemDescription: function() {
             this.$('.glossary-item-description').stop(true, true).slideUp(200);
             this.model.set('_isDescriptionOpen', false);
+
+            this.$('.glossary-item-term').removeClass('selected');
         },
 
         // This function will decide whether this glossary item's description should be visible or not.

--- a/js/adapt-contrib-glossaryItemView.js
+++ b/js/adapt-contrib-glossaryItemView.js
@@ -8,7 +8,7 @@ define(function(require) {
         className: "glossary-item",
 
         events: {
-            'click a.glossary-item-open': 'onGlossaryItemClicked'
+            'click a.glossary-item-term': 'onGlossaryItemClicked'
         },
 
         initialize: function() {

--- a/less/glossaryItem.less
+++ b/less/glossaryItem.less
@@ -8,7 +8,7 @@
         color:@drawer-item-text-color;
         border-bottom:1px solid darken(@item-color, 10%);
 
-        .no-touch &:hover {
+        .no-touch &:hover, &.selected {
             color:@drawer-item-text-hover-color;
             background-color:@drawer-item-hover-color;
         }

--- a/less/glossaryItem.less
+++ b/less/glossaryItem.less
@@ -2,7 +2,7 @@
     display:block;
     margin-top:@item-spacing;
 
-    .glossary-item-open {
+    .glossary-item-term {
         display:block;
         text-decoration:none;
         color:@drawer-item-text-color;
@@ -13,7 +13,7 @@
             background-color:@drawer-item-hover-color;
         }
 
-        .glossary-item-term {
+        .glossary-item-term-inner {
             padding:@item-padding;
 
             h5 {

--- a/templates/glossaryItem.hbs
+++ b/templates/glossaryItem.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Himanshu Rajotia <himanshu.rajotia@credipoint.com>}}
-<a class="glossary-item-open" href="#">
-    <div class="glossary-item-term">
-        <h5 class="glossary-item-term-inner">{{{term}}}</h5>
+<a class="glossary-item-term" href="#">
+    <div class="glossary-item-term-inner">
+        <h5>{{{term}}}</h5>
     </div>
 </a>
 <div class="glossary-item-description">


### PR DESCRIPTION
Allow selected glossary terms with an open description to be styled differently and made to stand out.  Also, rename glossary-item-open to glossary-item-term to remove the implied idea that the description is open.