### PR TITLE
remove 'app:languageChanged' event listener

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-glossary",
-  "version": "2.1.0",
-  "framework": ">=2.2.0",
+  "version": "2.1.1",
+  "framework": ">=2.2.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-glossary",
   "issues": "https://github.com/adaptlearning/adapt-contrib-glossary/issues",
   "displayName" : "Glossary",

--- a/js/adapt-contrib-glossary.js
+++ b/js/adapt-contrib-glossary.js
@@ -53,9 +53,6 @@ define([
         setupGlossary(courseGlossary, courseGlossary._glossaryItems);
     }
 
-    Adapt.once('app:dataReady', function() {
-        initGlossary();
-        Adapt.on('app:languageChanged', initGlossary);
-    });
+    Adapt.once('app:dataReady', initGlossary);
 
 });

--- a/js/adapt-contrib-glossary.js
+++ b/js/adapt-contrib-glossary.js
@@ -53,6 +53,6 @@ define([
         setupGlossary(courseGlossary, courseGlossary._glossaryItems);
     }
 
-    Adapt.once('app:dataReady', initGlossary);
+    Adapt.on('app:dataReady', initGlossary);
 
 });


### PR DESCRIPTION
as of Adapt v2.2.5 it's not longer needed

see https://github.com/adaptlearning/adapt_framework/issues/1917 and similar PR for Resources https://github.com/adaptlearning/adapt-contrib-resources/pull/55