### PR TITLE
issue/2799 Remove redundant behaviour

### DIFF
--- a/js/adapt-contrib-glossary.js
+++ b/js/adapt-contrib-glossary.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import drawer from 'core/js/drawer';
 import GlossaryView from './adapt-contrib-glossaryView';
 
 function setupGlossary(glossaryModel, glossaryItems) {
@@ -9,7 +10,7 @@ function setupGlossary(glossaryModel, glossaryItems) {
   };
 
   Adapt.on('glossary:showGlossary', () => {
-    Adapt.drawer.triggerCustomView(new GlossaryView(options).$el);
+    drawer.triggerCustomView(new GlossaryView(options).$el);
   });
 
   /**
@@ -27,7 +28,7 @@ function setupGlossary(glossaryModel, glossaryItems) {
       }
     };
 
-    Adapt.drawer.triggerCustomView(new GlossaryView(newOptions).$el);
+    drawer.triggerCustomView(new GlossaryView(newOptions).$el);
   });
 }
 
@@ -45,7 +46,7 @@ function initGlossary() {
     drawerOrder: courseGlossary._drawerOrder || 0
   };
 
-  Adapt.drawer.addItem(drawerObject, 'glossary:showGlossary');
+  drawer.addItem(drawerObject, 'glossary:showGlossary');
 
   setupGlossary(courseGlossary, courseGlossary._glossaryItems);
 }

--- a/js/adapt-contrib-glossaryItemView.js
+++ b/js/adapt-contrib-glossaryItemView.js
@@ -1,3 +1,4 @@
+import a11y from 'core/js/a11y';
 import Adapt from 'core/js/adapt';
 
 export default class GlossaryItemView extends Backbone.View {
@@ -69,7 +70,7 @@ export default class GlossaryItemView extends Backbone.View {
   showGlossaryItemDescription() {
     const $glossaryItemTerm = this.$('.js-glossary-item-term-click');
     const $description = $glossaryItemTerm.addClass('is-selected').siblings('.js-glossary-item-description').slideDown(200, () => {
-      Adapt.a11y.focusFirst($description, { defer: true });
+      a11y.focusFirst($description, { defer: true });
     });
     $glossaryItemTerm.attr('aria-expanded', true);
     this.model.set('_isDescriptionOpen', true);


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Use `drawer` and `a11y` directly