### PR TITLE
issue/3295 - Altering aria structure in drawer

### DIFF
--- a/js/adapt-contrib-glossaryView.js
+++ b/js/adapt-contrib-glossaryView.js
@@ -7,6 +7,12 @@ export default class GlossaryView extends Backbone.View {
     return 'glossary';
   }
 
+  attributes() {
+    return {
+      role: 'group'
+    };
+  }
+
   events() {
     return {
       'keyup .js-glossary-textbox-change': 'onInputTextBoxValueChange',


### PR DESCRIPTION
#3295 The drawer__holder is taking on the role of 'list'. Recommending making the top level glossary element a 'group'. https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#list