### PR TITLE
Fix: Toggle of class was needed to switch states for search icon

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/adapt-contrib-glossaryView.js
+++ b/js/adapt-contrib-glossaryView.js
@@ -234,7 +234,7 @@ export default class GlossaryView extends Backbone.View {
     const searchItemsAlert = this.model.get('searchItemsAlert') || '';
     const searchResults = (searchItem.length > 0);
     this.$('.js-glossary-cancel-btn-click').toggleClass('u-display-none', !searchResults);
-    this.$('.js-glossary-search-icon').addClass('u-display-none', searchResults);
+    this.$('.js-glossary-search-icon').toggleClass('u-display-none', searchResults);
     this.toggleHeaders(searchResults);
 
     if (searchResults) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #60 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Replaced an 'addClass' call with 'toggleClass' to insure 'u-display-none' class can be removed appropriately also

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Create a course with glossary and items
2. View drawer and search in area
3. Search icon will disappear and be replaced with X
4. Delete search text or click X
5. X will disappear
6. Search icon will reappear (was not previously)
