### PR TITLE
Fix: maintain search container position when scrolling or closing drawer (fixes #68)

### DIFF
--- a/js/adapt-contrib-glossaryView.js
+++ b/js/adapt-contrib-glossaryView.js
@@ -129,7 +129,6 @@ export default class GlossaryView extends Backbone.View {
     this.$('.js-glossary-index-container')
       .addClass('scrolling-down')
       .removeClass('scrolling-up');
-    this.$('.js-glossary-items-container').css('top', '0');
 
     this.prevScrollPos = currentScrollPos;
   }
@@ -211,18 +210,6 @@ export default class GlossaryView extends Backbone.View {
       this.$('.js-glossary-index-container')
         .css('margin-top', searchOuterHeight)
         .css('width', glossaryWidth);
-    }
-
-    if (isSearchEnabled && !isIndexEnabled) {
-      this.$('.js-glossary-items-container').css('top', searchOuterHeight + 'px');
-    }
-
-    if (isSearchEnabled && isIndexEnabled) {
-      this.$('.js-glossary-items-container').css('top', 'unset');
-    }
-
-    if (this.isSearchActive && isIndexEnabled) {
-      this.$('.js-glossary-items-container').css('top', searchOuterHeight);
     }
   }
 

--- a/js/adapt-contrib-glossaryView.js
+++ b/js/adapt-contrib-glossaryView.js
@@ -19,11 +19,9 @@ export default class GlossaryView extends Backbone.View {
 
   initialize() {
     this.itemViews = null;
-    this.prevScrollPos = 0;
     this.isSearchActive = false;
     this.listenTo(Adapt, 'remove drawer:closed', this.remove);
     this.setupModel();
-    this.onScroll = _.debounce(this.onScroll.bind(this), 200);
     this.onInputTextBoxValueChange = _.debounce(this.onInputTextBoxValueChange.bind(this), 200);
     _.defer(this.render.bind(this));
   }
@@ -102,35 +100,7 @@ export default class GlossaryView extends Backbone.View {
         _group: group
       }));
     });
-    this.prevScrollPos = $('.js-drawer-holder').scrollTop();
-    $('.js-drawer-holder').on('scroll', this.onScroll);
     this.$('.js-glossary-index-link').on('click', this.scrollToPosition);
-  }
-
-  onScroll() {
-    const currentScrollPos = $('.js-drawer-holder').scrollTop();
-    const indexDisplay = this.$('.js-glossary-index-container').css('display');
-    const isIndexVisible = indexDisplay !== 'none';
-
-    if (!isIndexVisible) {
-      this.prevScrollPos = currentScrollPos;
-      return;
-    }
-
-    if (this.prevScrollPos > currentScrollPos) {
-      this.$('.js-glossary-index-container')
-        .addClass('scrolling-up')
-        .removeClass('scrolling-down');
-      const indexOuterHeight = this.$('.js-glossary-index-container').outerHeight(true);
-      this.$('.js-glossary-items-container').css('top', indexOuterHeight + 'px');
-      return;
-    }
-
-    this.$('.js-glossary-index-container')
-      .addClass('scrolling-down')
-      .removeClass('scrolling-up');
-
-    this.prevScrollPos = currentScrollPos;
   }
 
   scrollToPosition(event) {
@@ -179,38 +149,12 @@ export default class GlossaryView extends Backbone.View {
   }
 
   postRender() {
-    const widthExclScrollbar = $('.drawer').prop('clientWidth');
-    $('.drawer__toolbar').css({
-      width: widthExclScrollbar + 'px',
-      'z-index': '2'
-    });
-
     this.listenTo(Adapt, {
       'drawer:openedItemView': this.remove,
       'drawer:triggerCustomView': this.remove
     });
 
-    this.configureContainers();
     this.checkForTermToShow();
-  }
-
-  configureContainers() {
-    const isSearchEnabled = this.model.get('_isSearchEnabled');
-    const isIndexEnabled = this.model.get('_isIndexEnabled');
-    const glossaryWidth = this.$('.js-glossary-inner').width();
-    const searchOuterHeight = this.$('.js-glossary-search-container').outerHeight(true);
-
-    if (isSearchEnabled) {
-      this.$('.js-glossary-search-container')
-        .css('width', glossaryWidth);
-      this.$('.js-glossary-item-not-found').css('top', searchOuterHeight + 'px');
-    }
-
-    if (isIndexEnabled) {
-      this.$('.js-glossary-index-container')
-        .css('margin-top', searchOuterHeight)
-        .css('width', glossaryWidth);
-    }
   }
 
   onInputTextBoxValueChange() {
@@ -226,14 +170,13 @@ export default class GlossaryView extends Backbone.View {
 
     if (searchResults) {
       const filteredItems = this.getFilteredGlossaryItems(searchItem, shouldSearchInDescription);
-      this.$('.js-glossary-alert').html(Handlebars.compile(searchItemsAlert)({ filteredItems: filteredItems }));
+      this.$('.js-glossary-alert').html(Handlebars.compile(searchItemsAlert)({ filteredItems }));
       this.showFilterGlossaryItems(filteredItems);
     } else {
       this.isSearchActive = false;
       this.showGlossaryItems(true);
     }
 
-    this.configureContainers();
     $('.js-drawer-holder').animate({ scrollTop: '0' });
   };
 

--- a/less/glossary.less
+++ b/less/glossary.less
@@ -33,14 +33,14 @@
   &__search-icon {
     position: absolute;
     top: 50%;
-    right: @item-padding / 2;
+    right: @item-padding * 2;
     padding: 0;
     .transform(translateY(-50%));
     background-color: transparent;
 
     .dir-rtl & {
       right: inherit;
-      left: @item-padding / 2;
+      left: @item-padding * 2;
     }
   }
 

--- a/less/glossary.less
+++ b/less/glossary.less
@@ -43,8 +43,7 @@
   }
 
   &__search-container {
-    position: fixed;
-    top: @navigation-height;
+    position: sticky;
     z-index: 2;
   }
 

--- a/less/glossary.less
+++ b/less/glossary.less
@@ -1,4 +1,14 @@
+.drawer__toolbar {
+  z-index: 2;
+}
+
 .glossary {
+  &__header {
+    position: sticky;
+    top: 0rem;
+    z-index: 1;
+  }
+
   &__textbox-container {
     position: relative;
   }
@@ -42,27 +52,12 @@
     .icon-cross;
   }
 
-  &__search-container {
-    position: sticky;
-    z-index: 2;
-  }
-
   &__index-container {
     position: relative;
     z-index: 1;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-around;
-  }
-
-  &__index-container.scrolling-up {
-    position: fixed;
-    z-index: 1;
-  }
-
-  &__index-container.scrolling-down {
-    position: relative;
-    z-index: 0;
   }
 
   &__items-container,


### PR DESCRIPTION
- sticky fix search container to maintain position when scrolling.
- top position is no longer required with sticky, css top removed from search and item containers.

Fixes https://github.com/adaptlearning/adapt-contrib-glossary/issues/68

I tested the latest changes across Chrome, FF and Safari on Mac. iPhone and Android tablet. It would be good if someone can just give this a look on windows please.
