### PR TITLE
Update: glossary item term aria-label added (fixes #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ The attributes listed below are used in *course.json* to configure **Glossary**,
 
 >**\_isGroupHeadersEnabled** (boolean): Turns the group headers on and off. Terms are alphabetized and grouped by their initial character (number or letter). Acceptable values are `true` and `false`. The default is `false`.  Headers are most effective when used with long lists of terms. If **\_isIndexEnabled** is set to `true`, **\_isGroupHeadersEnabled** will be set to `true` when the course is running, regardless of its original value.
 
->**\_glossaryItems** (object): This object stores properties for each glossary item. Multiple glossary items may be created. Each contains values for **term**  and **description**.
+>**\_glossaryItems** (object): This object stores properties for each glossary item. Multiple glossary items may be created. Each contains values for **term**, **termAriaLabel**  and **description**.
 
 >>**term** (string): The word or phrase that comprises the glossary term.
+
+>>**termAriaLabel** (string): Optional, reading of the word or phrase that comprises the glossary term. If unset, **term** provides the aria-label.
 
 >>**description** (string): This text is associated with each resource item. It renders as part of the aria label to tell screen readers that the content will open in an external link.
 

--- a/example.json
+++ b/example.json
@@ -18,7 +18,8 @@
                 "description": "The Adapt Framework is an open-source, reusable codebase for creating responsive e-learning courses.<br/>The Adapt Framework is designed to work with the Adapt Authoring Tool but can also be used in isolation."
             },
             {
-                "term": "Adapt Authoring Tool",
+                "term": "AAT",
+                "termAriaLabel": "Adapt Authoring Tool",
                 "description": "The Adapt authoring tool allows you to quickly build content using the Adapt Framework. You can create an account, log in, create courses, add interactive elements then preview and publish your content."
             },
             {

--- a/example.json
+++ b/example.json
@@ -20,7 +20,7 @@
             {
                 "term": "AAT",
                 "termAriaLabel": "Adapt Authoring Tool",
-                "description": "The Adapt authoring tool allows you to quickly build content using the Adapt Framework. You can create an account, log in, create courses, add interactive elements then preview and publish your content."
+                "description": "The {{a11y_alt_text 'AAT' 'aye aye tea'}} allows you to quickly build content using the Adapt Framework. You can create an account, log in, create courses, add interactive elements then preview and publish your content."
             },
             {
                 "term": "Responsive e-learning design",

--- a/properties.schema
+++ b/properties.schema
@@ -224,6 +224,18 @@
                         ],
                         "help": "The glossary item/term",
                         "translatable": true
+                      },
+                      "termAriaLabel": {
+                        "type": "string",
+                        "required": false,
+                        "default": "",
+                        "title": "Term ARIA label",
+                        "inputType": "Text",
+                        "validators": [
+                          "required"
+                        ],
+                        "help": "Optional, alternative label override for glossary item/term text",
+                        "translatable": true
                       }
                     }
                   }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -205,6 +205,15 @@
                     "_adapt": {
                       "translatable": true
                     }
+                  },
+                  "termAriaLabel": {
+                    "type": "string",
+                    "title": "Term ARIA label",
+                    "description": "Optional, alternative label override for glossary item/term text",
+                    "default": "",
+                    "_adapt": {
+                      "translatable": true
+                    }
                   }
                 }
               },

--- a/templates/glossaryItem.hbs
+++ b/templates/glossaryItem.hbs
@@ -1,7 +1,7 @@
 <button class="glossary__item-term drawer__item-btn js-glossary-item-term-click" aria-expanded="false" aria-label="{{#if termAriaLabel}}{{termAriaLabel}}{{else}}{{{term}}}{{/if}}">
   <span class="glossary__item-term-title drawer__item-title">
     <span class="glossary__item-term-title-inner drawer__item-title-inner">
-      {{{term}}}
+      {{{compile term}}}
     </span>
   </span>
 </button>

--- a/templates/glossaryItem.hbs
+++ b/templates/glossaryItem.hbs
@@ -1,4 +1,4 @@
-<button class="glossary__item-term drawer__item-btn js-glossary-item-term-click" aria-expanded="false" aria-label="{{{term}}}">
+<button class="glossary__item-term drawer__item-btn js-glossary-item-term-click" aria-expanded="false" aria-label="{{#if termAriaLabel}}{{termAriaLabel}}{{else}}{{{term}}}{{/if}}">
   <span class="glossary__item-term-title drawer__item-title">
     <span class="glossary__item-term-title-inner drawer__item-title-inner">
       {{{term}}}
@@ -6,7 +6,7 @@
   </span>
 </button>
 
-<div class="glossary__item-description js-glossary-item-description" role="region" aria-label="{{{term}}}">
+<div class="glossary__item-description js-glossary-item-description" role="region" aria-label="{{#if termAriaLabel}}{{termAriaLabel}}{{else}}{{{term}}}{{/if}}">
   <div class="glossary__item-description-inner">
     {{{compile description}}}
   </div>


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-glossary/issues/76

### Update
* `termAriaLabel` added to provide an optional reading of the word or phrase that comprises the glossary term. If unset, `term` provides the `aria-label`.
* compile glossaryItem `term` to support the use of Handlebars helper. Fixes #75 

### Testing
- Install and configure glossary as per [example](https://github.com/adaptlearning/adapt-contrib-glossary/blob/master/example.json).


